### PR TITLE
프로필카드 디자인(본인/타인), 관리메뉴 쪼끔 수정

### DIFF
--- a/cope/WebContent/client/profile.jsp
+++ b/cope/WebContent/client/profile.jsp
@@ -83,7 +83,11 @@ String root = request.getContextPath();
 					<span class="grade"><%=clientDto.getClientGradeKorean()%></span>
 					<img class="imgRound" src="https://dummyimage.com/200/<%=randomInt %>/ffffff&text=<%=ch %>" >
 					<h3><%=clientDto.getClientNick() %></h3>
+					<%if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo){%>
 					<h4><%=clientDto.getClientEmail() %></h4>
+					<%}else{%>
+					<h4><%=clientDto.getClientEmail().substring(1,3) %>********</h4>
+					<%} %>
 					<p>okky 회원</p>
 				</div>
 				

--- a/cope/WebContent/client/profile.jsp
+++ b/cope/WebContent/client/profile.jsp
@@ -1,3 +1,7 @@
+<%@page import="java.util.ArrayList"%>
+<%@page import="cope.beans.board.BoardDto"%>
+<%@page import="java.util.List"%>
+<%@page import="cope.beans.board.BoardDao"%>
 <%@page import="cope.beans.client.ClientDto"%>
 <%@page import="cope.beans.client.ClientDao"%>
 <%@page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
@@ -5,47 +9,181 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 <title></title>
-<link rel="stylesheet" type="text/css" href="<%=request.getContextPath() %>/css/common.css">
+<link rel="stylesheet" type="text/css" href="<%=request.getContextPath() %>/css/client.css">
 <%
+
+String root = request.getContextPath();
+//otherNo가 있으면 -> 다른사람 정보
+//otherNo가 없으면 -> 세션에서 clientNo를 가져와 내정보
+
 //파라미터는 남들도 내정보를볼수있으므로 세션으로 구현
 //Integer도 써도되지만 로그인후처리이므로 null값이 나올수가없어 int썻습니다
 //내정보불러오기
 	request.setCharacterEncoding("UTF-8");
 	int clientNo = (int)session.getAttribute("clientNo");
 	ClientDao clientDao = new ClientDao();
-	ClientDto clientDto = clientDao.myInfo(clientNo);
+	ClientDto clientDto = new ClientDto();
 	
+	if (request.getParameter("otherNo") == null) {
+	clientDto = clientDao.myInfo(clientNo);
+	}else if(Integer.parseInt(request.getParameter("otherNo"))==clientNo){
+	clientDto = clientDao.myInfo(clientNo);
+	}else{
+	clientDto = clientDao.myInfo(Integer.parseInt(request.getParameter("otherNo"))); 
+	}
 
+	
+//(석현)
+//위는 세션으로 불러오는 경우에 자신의 정보를 보게끔하고
+//다른 사람 정보는 파라미터로 받게하겠습니다(url에서 숨길 수 있으면 더 좋을 거 같은데 구현해보겠습니다.)
+
+	//아이디에 따라 랜덤 숫자 부여 placehodler에 사용할 예정!
+	String clientId = clientDto.getClientId();
+	char ch =  clientId.charAt(0);
+	int no = (int)ch;
+	
+	int seed = 216823123;
+	int randomInt= (seed/no)%1000000;
+	
+  BoardDao boardDao = new BoardDao();
+  List<BoardDto>boardSuperList = boardDao.showListBoardSuper();
+  List<Integer>countWritenpostList = new ArrayList<>();
+  if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo) {//otherNo가 없거나 otherNo가 본인이라면
+  	countWritenpostList = boardDao.countWritenPosts(clientNo, boardSuperList);
+  }else{
+	countWritenpostList = boardDao.countWritenPosts(Integer.parseInt(request.getParameter("otherNo")), boardSuperList); 
+  }
 %>
 
+<style>
+.chart{
+	width: 315px;
+	height: 200px;
+}
+</style>
 </head>
 <body>
-	
-		<div class="row">
-			<span>아이디 : <%=clientDto.getClientId() %></span>
-		</div>		
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.3.2/chart.min.js"></script>
+<jsp:include page="/template/aside.jsp"></jsp:include>
+<div class="main">
+	<div class="container-800 border">	
+
+		<%if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo){%>
+		<div class="row"><h2 class="text-center">내 프로필카드</h2></div>
+		<%}else{%>
+		<div class="row"><h2 class="text-center">회원 프로필카드</h2></div>
+		<%} %>
 		
-		<div class="row"><span>닉네임 : <%=clientDto.getClientNick() %></span></div>
-		<div class="row"><span>이메일 : <%=clientDto.getClientEmail() %></span></div>
-		<div class="row"><span>생년 : <%=clientDto.getClientBirthYear() %></span></div>
-		<div class="row"><span>등급 : <%=clientDto.getClientGrade() %></span></div>		
+<table class="table-card">
+<tbody>
+	<tr>
+		<td>
+			<div class="profile-card float-left">
+				<div class="profile-card-top">
+					<span class="grade"><%=clientDto.getClientGradeKorean()%></span>
+					<img class="imgRound" src="https://dummyimage.com/200/<%=randomInt %>/ffffff&text=<%=ch %>" >
+					<h3><%=clientDto.getClientNick() %></h3>
+					<h4><%=clientDto.getClientEmail() %></h4>
+					<p>okky 회원</p>
+				</div>
+				
+				<div class="profile-card-bottom">
+						<%if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo) {%>
+							<a href="<%=root%>/client/editInfo.jsp"><button class="client-btn">내 정보 수정</button></a>
+							<a href="<%=root%>/client/resetPw.jsp"><button class="client-btn">비밀번호 재설정</button></a>
+							<a href="<%=root%>/client/exit.jsp"><button class="client-btn">회원탈퇴</button></a>
+						<%}else{%>
+							
+						<%} %>
+
+				</div>
+			</div>
+		</td>
+		<td>
+		<div class="profile-card-back float-left">
+			<div class="profile-card-top">
 			
+				<%if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo){%>
+				<h2 class="text-center rid-margin">내 게시글 분석</h2>
+				<%}else{%>
+				<h2 class="text-center rid-margin">회원 게시글 분석</h2>
+				<%} %>			
+
 				
 				
 				
-	
-		
-		
-		<div class="row"><a href="<%=request.getContextPath()%>/board/myPostList.jsp">내글보기</a></div> 
-		<div class="row"><a href="<%=request.getContextPath()%>/board/myLikePost.jsp">내가 좋아요한 글</a></div>
-		<div class="row"><a href="editInfo.jsp">내정보 수정</a></div>
-		<div class="row"><a href="editPw.jsp">비밀번호 수정</a></div>
-		<div class="row"><a href="exit.jsp">탈퇴</a></div>
-		
-		
-		
-		
-		
+					<br>
+					<div class="chart">
+						<canvas id="postChartUser" ></canvas>
+					</div>
+					<script>
+					var boardSuperNames = [];
+					<%for(int i=0; i<boardSuperList.size(); i++){%>
+					boardSuperNames[<%=i%>] = '<%=boardSuperList.get(i).getBoardName()%>';
+					<%}%>
+					
+					var countWrttenpostArray =[];
+					<%for(int i=0; i<countWritenpostList.size(); i++){%>
+					countWrttenpostArray[<%=i%>] = <%=countWritenpostList.get(i)%>; // 배열을 복사합니다.
+					<%}%>	
+					
+					var ctx = document.getElementById('postChartUser').getContext('2d');
+					var myChart = new Chart(ctx, {
+					    type: 'bar',
+					    data: {
+					    	labels: boardSuperNames,
+					        datasets: [{
+					            label: '게시글 수',
+					            data: countWrttenpostArray,
+					            backgroundColor: [
+					                'rgba(255, 255, 153, 0.2)',
+					                'rgba(204, 255, 153, 0.2)',
+					                'rgba(102, 255, 204, 0.2)',
+					                'rgba(102, 255, 255, 0.2)',
+					                'rgba(204, 153, 255, 0.2)',
+					                'rgba(255, 153, 204, 0.2)',
+					                'rgba(51, 204, 204, 0.2)'
+					            ],
+					            borderColor: [
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)',
+					                'rgba(50, 50, 50, 1)'
+					            ],
+					            borderWidth: 1
+					        }]
+					    },
+					    options: {
+					    	
+					        scales: {
+					            x: {
+					                display: false,
+					              }
+					        }
+					    }
+					});	
+					</script>
+				</div>
+				<div class="profile-card-bottom">
+					<%if (request.getParameter("otherNo") == null || Integer.parseInt(request.getParameter("otherNo"))==clientNo){%>
+					<a href="#"><button class="client-btn">내 글 보기</button></a>
+					<%}else{%>
+					<a href="#"><button class="client-btn">회원 글 보기</button></a>
+					<%} %>	
+					<a href="#"><button class="client-btn">"좋아요"한 글 보기</button></a>
+				</div>
+			</div>
+		</td>
+	</tr>
+</tbody>
+</table>
+
+<br><br><br>
+</div>
+</div>
 		
 <!-- 		테스트세션 -->
 		세션번호<%=session.getAttribute("clientNo") %> 

--- a/cope/WebContent/manage/manageCenter.jsp
+++ b/cope/WebContent/manage/manageCenter.jsp
@@ -63,8 +63,7 @@
 							    data: {
 							        labels: ['10대이하', '10대', '20대', '30대', '40대', '50대', '60대', '70대'],
 							        datasets: [{
-							            label: '# of Votes',
-							//             data: [12, 19, 3, 5, 2, 3],
+							            label: '연령분포',
 							            data: ageRangeArray,
 							            backgroundColor: [
 							                'rgba(255, 255, 153, 0.2)',
@@ -119,10 +118,8 @@
 							    type: 'pie',
 							    data: {
 							    	labels: boardSuperNames,
-// 							        labels: ['10대이하', '10대', '20대', '30대', '40대'],
 							        datasets: [{
-							            label: '# of Votes',
-// 							            data: [12, 19, 3, 5, 2, 3],
+							            label: '게시판 비율',
 							            data: countUnderpostArray,
 							            backgroundColor: [
 							                'rgba(255, 255, 153, 0.2)',

--- a/cope/WebContent/manage/manageClient.jsp
+++ b/cope/WebContent/manage/manageClient.jsp
@@ -220,7 +220,7 @@
 					<tr>
 						<td><%=clientDto.getClientNo()%></td>
 						<td><%=clientDto.getClientId()%></td>
-						<td><a href=""><%=clientDto.getClientNick()%></a></td>
+						<td><a href="<%=root%>/client.jsp?clientNo=<%=clientDto.getClientNo()%>"><%=clientDto.getClientNick()%></a></td>
 						<td><%=clientDto.getClientEmail()%></td>
 						<td>
 							<%if (clientDto.getClientBirthYear() == 0) {%>


### PR DESCRIPTION
프로필카드 디자인 했습니다.
otherNo를 파라미터로 가져와서

otherNo가 있으면 -> 다른사람 정보
otherNo가 없으면 -> 세션에서 clientNo를 가져와 내정보

내 정보 / 회원정보
내 게시글 / 회원게시글

그리고 다른 사람은 이메일 뒷부분****처리도 가능하게 되었습니다.

참고 사이트.

프로필 카드
https://designrshub.com/2020/09/free-profile-card-css.html를 참고했습니다. (거의 배낌요 ㅋㅋ 하지만 티 안나게...)

더미 이미지
https://dummyimage.com/
아이디의 첫 글자에 따라 글씨색이 바뀌고 글자도 들어가게 했습니다. 한글도 되는 더미이미지가 있으면 좋겠네요

